### PR TITLE
Update preferences.glade

### DIFF
--- a/terminatorlib/preferences.glade
+++ b/terminatorlib/preferences.glade
@@ -3874,7 +3874,7 @@
                         </child>
                         <child>
                           <object class="GtkButton" id="layoutrefreshbutton">
-                            <property name="label">gtk-save</property>
+                            <property name="label">gtk-refresh</property>
                             <property name="use-action-appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>


### PR DESCRIPTION
- change the layoutrefreshbutton to use gtk-refresh instead of the gtk-save
- this indicates the correct button behaviour and brings it in line with what the code actually does
- 'fixes' https://github.com/gnome-terminator/docs/issues/21